### PR TITLE
Update README explaining that the layout needs a gyroscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For bugs, requests, questions and discussions please use [Github Issues](https:/
 This library was developed by [Rafa Vázquez](https://github.com/Sloy/) with the idea of moving images from [Alex Bailón](https://github.com/abailon) for the [Infojobs' Android application](https://play.google.com/store/apps/details?id=net.infojobs.mobile.android).
 
 # Device requirements
-This layout needs a gyroscope powered device. Sadly, there are some low-end phones that doesn't have it. In that case, the layed image won't move, but it will appear great.
+This layout needs a gyroscope powered device. Sadly, there are some low-end phones that doesn't have it. In that case, the layered image won't move, but it will appear great.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ For bugs, requests, questions and discussions please use [Github Issues](https:/
 # Attributions
 This library was developed by [Rafa Vázquez](https://github.com/Sloy/) with the idea of moving images from [Alex Bailón](https://github.com/abailon) for the [Infojobs' Android application](https://play.google.com/store/apps/details?id=net.infojobs.mobile.android).
 
+# Device requirements
+This layout needs a gyroscope powered device. Sadly, there are some low-end phones that doesn't have it. In that case, the layed image won't move, but it will appear great.
+
 # License
 
 ```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For bugs, requests, questions and discussions please use [Github Issues](https:/
 This library was developed by [Rafa Vázquez](https://github.com/Sloy/) with the idea of moving images from [Alex Bailón](https://github.com/abailon) for the [Infojobs' Android application](https://play.google.com/store/apps/details?id=net.infojobs.mobile.android).
 
 # Device requirements
-This layout needs a gyroscope powered device. Sadly, there are some low-end phones that doesn't have it. In that case, the layered image won't move, but it will appear great.
+This layout needs a gyroscope powered device. Sadly, there are some low-end phones that doesn't have it. In that case, the layered will appear like a static image.
 
 # License
 


### PR DESCRIPTION
Related with #8, we tried to develop a version that simply uses the accelerometer and the compass... but we failed using phones that don't have some of that sensors. Incredible.

As the complexity of the library grows exponentially, we will simply talk about using a phone with a gyroscope in the readme. The layout shows the image also with low-end phones that don't have those sensors, so it's not a big deal.
