### PR TITLE
Avoid registering the sensor if it's null

### DIFF
--- a/library/src/main/java/com/schibsted/spain/parallaxlayerlayout/SensorTranslationUpdater.java
+++ b/library/src/main/java/com/schibsted/spain/parallaxlayerlayout/SensorTranslationUpdater.java
@@ -44,8 +44,10 @@ public class SensorTranslationUpdater
 
   public void registerSensorManager() {
     if (sensorManager != null) {
-      sensorManager.registerListener(this,
-          sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR), DEFAULT_SAMPLING_PERIOD);
+      Sensor rotationVectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR);
+      if (rotationVectorSensor != null) {
+        sensorManager.registerListener(this, rotationVectorSensor, DEFAULT_SAMPLING_PERIOD);
+      }
     }
   }
 


### PR DESCRIPTION
For some reason, some phones return a null sensor when getting the default one. So, we will check for it before registering the sensort to avoid crashes like http://crashes.to/s/2fd03a11431

BTW, sorry for the last line. I edited the file using the website so I don't have any idea about why it has changed :·/