### PR TITLE
Fixed code constructor + onFinishInflate not called

### DIFF
--- a/library/src/main/java/com/schibsted/spain/parallaxlayerlayout/ParallaxLayerLayout.java
+++ b/library/src/main/java/com/schibsted/spain/parallaxlayerlayout/ParallaxLayerLayout.java
@@ -25,7 +25,7 @@ public class ParallaxLayerLayout extends FrameLayout {
   private TranslationUpdater translationUpdater;
 
   public ParallaxLayerLayout(Context context) {
-    super(context);
+    this(context, null);
   }
 
   public ParallaxLayerLayout(Context context, AttributeSet attrs) {
@@ -62,6 +62,17 @@ public class ParallaxLayerLayout extends FrameLayout {
   @Override
   protected void onFinishInflate() {
     super.onFinishInflate();
+
+    computeOffsets();
+
+    if (isInEditMode()) {
+      updateTranslations(new float[] { 1.0f, 1.0f });
+    }
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    super.onLayout(changed, left, top, right, bottom);
 
     computeOffsets();
 


### PR DESCRIPTION
Hi :)
I just fixed the first constructor : it was not initiating correctly because it just called `super`. 

And I added the `computeOffsets` in the onLayout callback. In fact, the onFinishInflate() is only called when the Layout is created from XML.
I am now using your Layout in a Jetpack Compose `AndroidView` 😄 